### PR TITLE
Few improvements to reduce/eliminate corrupt MP3 files

### DIFF
--- a/spotifyripper.py
+++ b/spotifyripper.py
@@ -109,8 +109,13 @@ def convert_to_mp3(a_file_input, a_file_cover, a_album, a_artist, a_title, a_tra
     if a_file_output_size > 25485760:
         print('\033[33m' + "Warning: large file " + a_file_output + " \033[0m\n")
 
-    # print("DELETE " + a_file_cover)
-    os.remove(a_file_cover)
+    external_cover_file = os.path.dirname(a_file_cover) + "/cover.jpg"
+    if not os.path.isfile(external_cover_file):
+        os.rename(a_file_cover, external_cover_file)
+    else:
+        # print("DELETE " + a_file_cover)
+        os.remove(a_file_cover)
+
     # print("DELETE " + a_file_input)
     os.remove(a_temp_file_input)
     #print("convert_to_mp3: done converting " + a_file_input)

--- a/spotifyripper.py
+++ b/spotifyripper.py
@@ -147,6 +147,9 @@ def spotify_handler(*args):
     # if albumArtist != "":
     #     artist = albumArtist
     
+    if albumArtist == "":
+        albumArtist = artist
+
     if title != "":
         title = title.replace("/", "-")
         
@@ -169,7 +172,7 @@ def spotify_handler(*args):
             disc_number_str = str(disc_number) + " "
         else:
             disc_number_str = ""
-        path_album = create_directory(path_base + "/" + artist + "/" + disc_number_str + album)
+        path_album = create_directory(path_base + "/" + albumArtist + "/" + disc_number_str + album)
         # print("path_album: " + path_album)
 
         # record stream

--- a/spotifyripper.py
+++ b/spotifyripper.py
@@ -35,8 +35,9 @@ spotify_sink_index = -1
 def get_spotify_sink_index():
     with pulsectl.Pulse('spotify') as pulse:
         for sink in pulse.sink_input_list():
-            # print("sink.name:" + sink.name)
-            # print("sink.corked:" + str(sink.corked))
+            # if (sink.name == "Spotify"):
+                # print("sink.name:" + sink.name)
+                # print("sink.corked:" + str(sink.corked))
             if (sink.name == "Spotify") and (sink.corked == False):
                 return sink.index
 
@@ -171,7 +172,7 @@ def spotify_handler(*args):
 
     metadata = args[1]["Metadata"]
     # debug
-    #pprint.pprint(metadata)
+    # pprint.pprint(metadata)
 
     artist = metadata["xesam:artist"][0]
     #print("Artist: " + artist)
@@ -219,14 +220,17 @@ def spotify_handler(*args):
             pre_subprocess.terminate()
         file_input = path_album + "/" + str(track_number) + " - " + artist + " - " + title + ".wav"
 
+        # refresh spotify_sink_index
+        old_spotify_sink_index = spotify_sink_index
+        spotify_sink_index = get_spotify_sink_index()
+        if (old_spotify_sink_index != spotify_sink_index):
+            print("(info) spotify_sink_index: " + str(spotify_sink_index))
+
+        # If Spotify not found, do nothing
         if spotify_sink_index == -1:
-            spotify_sink_index = get_spotify_sink_index()
-            print("spotify_sink_index: " + str(spotify_sink_index))
-            # If Spotify not found, do nothing
-            if spotify_sink_index == -1:
-                print("the Spotify client is not found.")
-                print("It has to be registered with the audio server by playing a sound.")
-                return
+            print("the Spotify client is not found.")
+            print("It has to be registered with the audio server by playing a sound.")
+            return
 
 
         if (artist != "") or (album != ""):

--- a/spotifyripper.py
+++ b/spotifyripper.py
@@ -179,7 +179,7 @@ def spotify_handler(*args):
             print("spotify_sink_index: " + str(spotify_sink_index))
             # If Spotify not found, do nothing
             if spotify_sink_index == -1:
-                print("the Spotify client not found.")
+                print("the Spotify client is not found.")
                 print("It has to be registered with the audio server by playing a sound.")
                 return
 

--- a/spotifyripper.py
+++ b/spotifyripper.py
@@ -129,13 +129,12 @@ def spotify_handler(*args):
 
     metadata = args[1]["Metadata"]
     # debug
-    # pprint.pprint(metadata)
-
+    #pprint.pprint(metadata)
 
     artist = metadata["xesam:artist"][0]
-    # print("Artist: " + artist)
-    #albumArtist = metadata["xesam:albumArtist"][0]
-    # print("AArtist " + albumArtist)
+    #print("Artist: " + artist)
+    albumArtist = metadata["xesam:albumArtist"][0]
+    #print("AArtist " + albumArtist)
     title = metadata["xesam:title"]
     album = metadata["xesam:album"]
     track_number = metadata["xesam:trackNumber"]
@@ -153,6 +152,7 @@ def spotify_handler(*args):
 
     if title != pre_title:
         print("Artist: " + artist)
+        print("AlbumArtist: " + albumArtist)
         print("Album: " + album)
         print("Title: " + str(track_number) + " - " + title)
         # print("Cover: " + art_url)

--- a/spotifyripper.py
+++ b/spotifyripper.py
@@ -5,6 +5,7 @@
 
 import dbus
 import os
+import sys
 import pprint
 import pulsectl
 import re
@@ -25,6 +26,7 @@ pre_track_number = ""
 pre_file_input = ""
 pre_file_cover = ""
 file_cover = ""
+download_path = ""
 spotify_sink_index = 0
 
 
@@ -52,6 +54,22 @@ def create_directory(path_album):
         return "/tmp"
 
     return path_album
+
+
+def get_download_path():
+    if sys.platform == "win32":
+        command = r'reg query "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /v "Downloads"'
+        result = subprocess.run(command, stdout=subprocess.PIPE, text = True)
+        download_path = result.stdout.splitlines()[2].split()[2]
+    else:
+        download_path = subprocess.check_output(['xdg-user-dir', 'DOWNLOAD'], text = True).rstrip('\n')
+
+    if download_path == "":
+        download_path = os.path.expanduser("~/Downloads")
+
+    download_path = os.path.join(download_path, 'spotifyripper')
+    print("download_path =  %s" % download_path)
+    return download_path
 
 
 def download_cover(art_url, file_cover):
@@ -105,6 +123,7 @@ def spotify_handler(*args):
     global pre_track_number
     global pre_file_input
     global pre_file_cover
+    global download_path
     global r
     global spotify_sink_index
 
@@ -141,9 +160,8 @@ def spotify_handler(*args):
         print()
 
 
-
         # create dir
-        path_base = os.path.expanduser("~/Downloads/spotifyripper")
+        path_base = os.path.expanduser(download_path)
         if disc_number > 1:
             disc_number_str = str(disc_number) + " "
         else:
@@ -187,6 +205,7 @@ def spotify_handler(*args):
         pre_track_number = track_number
 
 
+download_path = get_download_path()
 spotify_sink_index = get_spotify_sink_index()
 
 DBusGMainLoop(set_as_default=True)

--- a/spotifyripper.py
+++ b/spotifyripper.py
@@ -6,6 +6,7 @@
 import dbus
 import os
 import sys
+import time
 import pprint
 import pulsectl
 import re
@@ -27,6 +28,7 @@ pre_file_input = ""
 pre_file_cover = ""
 file_cover = ""
 download_path = ""
+advertisement_detected = False
 spotify_sink_index = -1
 
 
@@ -125,6 +127,7 @@ def spotify_handler(*args):
     global pre_file_cover
     global download_path
     global r
+    global advertisement_detected
     global spotify_sink_index
 
     metadata = args[1]["Metadata"]
@@ -185,7 +188,12 @@ def spotify_handler(*args):
 
 
         if (artist != "") or (album != ""):
+            # parec starts too soon after the advertisement bits.
+            # Add 1s delay in order to skip the end of the advertisement.
+            if advertisement_detected == True:
+                time.sleep(1)
             pre_subprocess = subprocess.Popen(["parec",  "--monitor-stream=" + str(spotify_sink_index), "--file-format=wav", file_input])
+            advertisement_detected = False
 
         # convert previous file
         if os.path.isfile(pre_file_input):
@@ -209,6 +217,8 @@ def spotify_handler(*args):
         pre_title = title
     if track_number != "":        
         pre_track_number = track_number
+    if (artist == "") and (album == ""):
+        advertisement_detected = True
 
 
 download_path = get_download_path()

--- a/spotifyripper.py
+++ b/spotifyripper.py
@@ -121,6 +121,40 @@ def convert_to_mp3(a_file_input, a_file_cover, a_album, a_artist, a_title, a_tra
     #print("convert_to_mp3: done converting " + a_file_input)
 
 
+def convert_to_opus(a_file_input, a_file_cover, a_album, a_artist, a_title, a_track_number):
+    # Use internal filename to Protect from successive conversion
+    a_temp_file_input = a_file_input.replace(".wav", "-tmp.wav")
+    a_file_output = a_file_input.replace(".wav", ".opus")
+    os.rename(a_file_input, a_temp_file_input)
+
+    sound = AudioSegment.from_wav(a_temp_file_input)
+    # Recommended: Opus at 128 KB/s (VBR) is pretty much transparent
+    sound.export(a_file_output, format="opus", codec="libopus", bitrate="192k", tags={
+            "album": a_album,
+            "artist": a_artist,
+            "title": a_title,
+            "track": int(a_track_number)
+        }
+    )
+
+    a_file_output_size = os.stat(a_file_output).st_size
+    if a_file_output_size < 1048576:
+        print('\033[33m' + "Warning: small file " + a_file_output + " \033[0m\n")
+
+    if a_file_output_size > 25485760:
+        print('\033[33m' + "Warning: large file " + a_file_output + " \033[0m\n")
+
+    external_cover_file = os.path.dirname(a_file_cover) + "/cover.jpg"
+    if not os.path.isfile(external_cover_file):
+        os.rename(a_file_cover, external_cover_file)
+    else:
+        # print("DELETE " + a_file_cover)
+        os.remove(a_file_cover)
+
+    # print("DELETE " + a_file_input)
+    os.remove(a_temp_file_input)
+
+
 def spotify_handler(*args):
     global pre_album
     global pre_artist
@@ -206,6 +240,7 @@ def spotify_handler(*args):
         # convert previous file
         if os.path.isfile(pre_file_input):
             Process(target=convert_to_mp3, args=(pre_file_input, pre_file_cover, pre_album, pre_artist, pre_title, pre_track_number)).start()
+            # Process(target=convert_to_opus, args=(pre_file_input, pre_file_cover, pre_album, pre_artist, pre_title, pre_track_number)).start()
 
         # download cover
         file_cover = file_input.replace(".wav", ".jpg")

--- a/spotifyripper.py
+++ b/spotifyripper.py
@@ -27,7 +27,7 @@ pre_file_input = ""
 pre_file_cover = ""
 file_cover = ""
 download_path = ""
-spotify_sink_index = 0
+spotify_sink_index = -1
 
 
 def get_spotify_sink_index():
@@ -38,7 +38,7 @@ def get_spotify_sink_index():
             if (sink.name == "Spotify") and (sink.corked == False):
                 return sink.index
 
-    return 0
+    return -1
 
 
 def create_directory(path_album):
@@ -174,9 +174,15 @@ def spotify_handler(*args):
             pre_subprocess.terminate()
         file_input = path_album + "/" + str(track_number) + " - " + artist + " - " + title + ".wav"
 
-        if spotify_sink_index == 0:
+        if spotify_sink_index == -1:
             spotify_sink_index = get_spotify_sink_index()
             print("spotify_sink_index: " + str(spotify_sink_index))
+            # If Spotify not found, do nothing
+            if spotify_sink_index == -1:
+                print("the Spotify client not found.")
+                print("It has to be registered with the audio server by playing a sound.")
+                return
+
 
         if (artist != "") or (album != ""):
             pre_subprocess = subprocess.Popen(["parec",  "--monitor-stream=" + str(spotify_sink_index), "--file-format=wav", file_input])

--- a/spotifyripper.py
+++ b/spotifyripper.py
@@ -92,7 +92,7 @@ def convert_to_mp3(a_file_input, a_file_cover, a_album, a_artist, a_title, a_tra
     os.rename(a_file_input, a_temp_file_input)
 
     sound = AudioSegment.from_wav(a_temp_file_input)
-    sound.export(a_file_output, format="mp3", bitrate="160k", cover=a_file_cover, tags={
+    sound.export(a_file_output, format="mp3", bitrate="320k", cover=a_file_cover, tags={
             "album": a_album,
             "artist": a_artist,
             "title": a_title,
@@ -104,7 +104,7 @@ def convert_to_mp3(a_file_input, a_file_cover, a_album, a_artist, a_title, a_tra
     if a_file_output_size < 1048576:
         print('\033[33m' + "Warning: small file " + a_file_output + " \033[0m\n")
 
-    if a_file_output_size > 10485760:
+    if a_file_output_size > 25485760:
         print('\033[33m' + "Warning: large file " + a_file_output + " \033[0m\n")
 
     # print("DELETE " + a_file_cover)


### PR DESCRIPTION
- Reduces the problem of corrupt .MP3 file for the track just before advertisement track: that track was not fully converted even though the WAV file was OK.
- The download path is system/language-independent (although not tested on win32).
- The bitrate is optionally increased to 320k, not sure if it is helpful.
- Display an error message when the Spotify client is not registered with the audio server.

- Remaining issue : the recording of the track just after advertisement bits still starts a little too earlier (~1 second on my system). ~Have not yet find out the way to filter out the related dbus messages avalanche and start the parec subprocess at the right moment. The quick workaround is to replay that track if needed or edit it with some software such as audacity.~
- The issue seems to be solved in the last commit by adding extra delay before the parec subprocess